### PR TITLE
FEAT: the imported directives are configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules/
 
 Gemfile.lock
 gemfiles/*.gemfile.lock
+
+.idea

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -115,7 +115,7 @@ module ApolloFederation
     end
 
     def directive_name(directive)
-      if schema.federation_2? && !Schema::IMPORTED_DIRECTIVES.include?(directive[:name])
+      if schema.federation_2? && !schema.get_imported_directives.include?(directive[:name])
         "#{schema.link_namespace}__#{directive[:name]}"
       else
         directive[:name]

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -115,7 +115,7 @@ module ApolloFederation
     end
 
     def directive_name(directive)
-      if schema.federation_2? && !schema.get_imported_directives.include?(directive[:name])
+      if schema.federation_2? && !schema.imported_directives.include?(directive[:name])
         "#{schema.link_namespace}__#{directive[:name]}"
       else
         directive[:name]

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -25,7 +25,7 @@ module ApolloFederation
       end
 
       def set_imported_directives(directives)
-        @imported_directives = (DEFAULT_IMPORTED_DIRECTIVES + directives).uniq
+        @imported_directives = directives.uniq
       end
 
       def imported_directives

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,14 +7,13 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    class_attribute :imported_directives, default: %w[inaccessible tag].freeze
-
     def self.included(klass)
       klass.extend(CommonMethods)
     end
 
     module CommonMethods
       DEFAULT_LINK_NAMESPACE = 'federation'
+      DEFAULT_IMPORTED_DIRECTIVES = %w[inaccessible tag].freeze
 
       def federation(version: '1.0', link: {})
         @federation_version = version
@@ -23,6 +22,14 @@ module ApolloFederation
 
       def federation_version
         @federation_version || find_inherited_value(:federation_version, '1.0')
+      end
+
+      def set_imported_directives(directives)
+        @imported_directives = (DEFAULT_IMPORTED_DIRECTIVES + directives).uniq
+      end
+
+      def imported_directives
+        @imported_directives || DEFAULT_IMPORTED_DIRECTIVES
       end
 
       def federation_2?
@@ -64,7 +71,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(get_imported_directives.map { |directive| "\"@#{directive}\"" }).join(', ')}])
+            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(imported_directives.map { |directive| "\"@#{directive}\"" }).join(', ')}])
 
         SCHEMA
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -71,7 +71,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(@imported_directives.map { |directive| "\"@#{directive}\"" }).join(', ')}])
+            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(get_imported_directives.map { |directive| "\"@#{directive}\"" }).join(', ')}])
 
         SCHEMA
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,7 +7,7 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = ['inaccessible', 'tag'].freeze
+    IMPORTED_DIRECTIVES = %w[inaccessible tag key].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -25,7 +25,7 @@ module ApolloFederation
       end
 
       def set_imported_directives(directives)
-        @imported_directives = DEFAULT_IMPORTED_DIRECTIVES + directives
+        @imported_directives = (DEFAULT_IMPORTED_DIRECTIVES + directives).uniq
       end
 
       def get_imported_directives

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,7 +7,7 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = %w[inaccessible tag key].freeze
+    IMPORTED_DIRECTIVES = %w[inaccessible tag key shareable].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -24,7 +24,7 @@ module ApolloFederation
         @federation_version || find_inherited_value(:federation_version, '1.0')
       end
 
-      def set_imported_directives(directives)
+      def import_directives(directives)
         @imported_directives = directives.uniq
       end
 

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,13 +7,14 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
+    class_attribute :imported_directives, default: %w[inaccessible tag].freeze
+
     def self.included(klass)
       klass.extend(CommonMethods)
     end
 
     module CommonMethods
       DEFAULT_LINK_NAMESPACE = 'federation'
-      DEFAULT_IMPORTED_DIRECTIVES = %w[inaccessible tag].freeze
 
       def federation(version: '1.0', link: {})
         @federation_version = version
@@ -22,14 +23,6 @@ module ApolloFederation
 
       def federation_version
         @federation_version || find_inherited_value(:federation_version, '1.0')
-      end
-
-      def set_imported_directives(directives)
-        @imported_directives = (DEFAULT_IMPORTED_DIRECTIVES + directives).uniq
-      end
-
-      def get_imported_directives
-        @imported_directives || DEFAULT_IMPORTED_DIRECTIVES
       end
 
       def federation_2?

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,14 +7,13 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = %w[inaccessible tag key shareable].freeze
-
     def self.included(klass)
       klass.extend(CommonMethods)
     end
 
     module CommonMethods
       DEFAULT_LINK_NAMESPACE = 'federation'
+      DEFAULT_IMPORTED_DIRECTIVES = %w[inaccessible tag].freeze
 
       def federation(version: '1.0', link: {})
         @federation_version = version
@@ -23,6 +22,14 @@ module ApolloFederation
 
       def federation_version
         @federation_version || find_inherited_value(:federation_version, '1.0')
+      end
+
+      def set_imported_directives(directives)
+        @imported_directives = DEFAULT_IMPORTED_DIRECTIVES + directives
+      end
+
+      def get_imported_directives
+        @imported_directives || DEFAULT_IMPORTED_DIRECTIVES
       end
 
       def federation_2?
@@ -64,7 +71,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(IMPORTED_DIRECTIVES.map { |directive| "\"@#{directive}\"" }).join(', ')}])
+            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(@imported_directives.map { |directive| "\"@#{directive}\"" }).join(', ')}])
 
         SCHEMA
       end

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @federation__key(fields: "upc") {
+            type Product @key(fields: "upc") {
               upc: String!
             }
 
@@ -136,9 +136,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @federation__key(fields: "upc") {
+            type Product @key(fields: "upc") {
               upc: String!
             }
           GRAPHQL
@@ -175,7 +175,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             upc: String!
@@ -210,7 +210,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product @federation__extends {
             upc: String!
@@ -246,7 +246,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position @federation__shareable {
             x: Int!
@@ -283,7 +283,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position @inaccessible {
             x: Int!
@@ -320,7 +320,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position @tag(name: "private") {
             x: Int!
@@ -357,7 +357,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Product @fed2__extends {
               upc: String!
@@ -393,7 +393,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Position @fed2__shareable {
               x: Int!
@@ -430,7 +430,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Position @inaccessible {
               x: Int!
@@ -467,7 +467,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Position @tag(name: "private") {
               x: Int!
@@ -503,7 +503,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -534,7 +534,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -561,7 +561,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -615,7 +615,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Book implements Product {
             upc: String!
@@ -672,7 +672,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Book implements Product {
             upc: String!
@@ -735,17 +735,17 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Book implements Product @federation__extends @federation__key(fields: "upc") {
+          type Book implements Product @federation__extends @key(fields: "upc") {
             upc: String! @federation__external
           }
 
-          type Pen implements Product @federation__key(fields: "upc") {
+          type Pen implements Product @key(fields: "upc") {
             upc: String!
           }
 
-          interface Product @federation__key(fields: "upc") {
+          interface Product @key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -791,7 +791,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Book {
             upc: String!
@@ -840,7 +840,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Book {
             upc: String!
@@ -883,7 +883,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           enum ProductType @tag(name: "private") {
             BOOK
@@ -925,7 +925,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           enum ProductType @inaccessible {
             BOOK
@@ -966,7 +966,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             upc: UPC!
@@ -1012,7 +1012,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             upc: UPC!
@@ -1062,7 +1062,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1117,7 +1117,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1172,7 +1172,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1227,7 +1227,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1276,7 +1276,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1321,7 +1321,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1355,9 +1355,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
+          type Product @key(fields: "upc") @key(fields: "name") {
             name: String
             upc: String!
           }
@@ -1381,9 +1381,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__key(fields: "upc", resolvable: false) {
+          type Product @key(fields: "upc", resolvable: false) {
             upc: String!
           }
         GRAPHQL
@@ -1406,9 +1406,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__key(fields: "upc") {
+          type Product @key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -1433,9 +1433,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
+          type Product @federation__extends @key(fields: "upc") {
             price: Int
             upc: String! @federation__external
           }
@@ -1460,9 +1460,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__interfaceObject @federation__key(fields: "id") {
+          type Product @federation__interfaceObject @key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -1491,7 +1491,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position {
             x: Int! @federation__shareable
@@ -1527,7 +1527,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position {
             x: Int! @inaccessible
@@ -1563,7 +1563,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position {
             x: Int! @tag(name: "private")
@@ -1599,7 +1599,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position {
             x: Int! @tag(name: "private") @tag(name: "protected")
@@ -1651,7 +1651,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             type: ProductType!
@@ -1707,7 +1707,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             type: ProductType!
@@ -1763,7 +1763,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product {
             type: ProductType!
@@ -1799,9 +1799,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__extends @federation__key(fields: "id") {
+          type Product @federation__extends @key(fields: "id") {
             id: ID!
             isStock: Boolean! @federation__override(from: "Products")
           }
@@ -1835,14 +1835,14 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
+          type Product @federation__extends @key(fields: "upc") {
             price: Int
             upc: String! @federation__external
           }
 
-          type Review @federation__key(fields: "id") {
+          type Review @key(fields: "id") {
             id: ID!
             product: Product @federation__provides(fields: "upc")
           }
@@ -1870,9 +1870,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
+          type Product @federation__extends @key(fields: "upc") {
             price: Int @federation__external
             shippingEstimate: Int @federation__requires(fields: "price weight")
             upc: String! @federation__external
@@ -1899,9 +1899,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @federation__key(fields: "productId") {
+            type Product @key(fields: "productId") {
               productId: String!
             }
           GRAPHQL
@@ -1927,9 +1927,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @federation__extends @federation__key(fields: "product_id") {
+            type Product @federation__extends @key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
               otherOptions: [String!]! @federation__requires(fields: "myId")
               product_id: String!
@@ -1960,9 +1960,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
+          type Product @federation__extends @key(fields: "upc") {
             upc: String! @federation__external
           }
         GRAPHQL
@@ -1988,9 +1988,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Product @federation__key(fields: "id") {
+          type Product @key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -2022,7 +2022,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product @fed2__extends {
             upc: String!
@@ -2059,7 +2059,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Product @fed2__extends {
             upc: String!

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe ApolloFederation::ServiceField do
           extend schema
             @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-          type Position @federation__shareable {
+          type Position @shareable {
             x: Int!
             y: Int!
           }
@@ -395,7 +395,7 @@ RSpec.describe ApolloFederation::ServiceField do
             extend schema
               @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Position @fed2__shareable {
+            type Position @shareable {
               x: Int!
               y: Int!
             }
@@ -505,7 +505,7 @@ RSpec.describe ApolloFederation::ServiceField do
             extend schema
               @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @fed2__key(fields: "upc") {
+            type Product @key(fields: "upc") {
               upc: String!
             }
 
@@ -563,7 +563,7 @@ RSpec.describe ApolloFederation::ServiceField do
             extend schema
               @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @fed2__interfaceObject @fed2__key(fields: "id") {
+            type Product @fed2__interfaceObject @key(fields: "id") {
               id: ID!
             }
           GRAPHQL

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe ApolloFederation::ServiceField do
             extend schema
               @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
-            type Product @fed2__extends @fed2__key(fields: "upc") {
+            type Product @fed2__extends @key(fields: "upc") {
               price: Int
               upc: String! @fed2__external
             }
@@ -1494,8 +1494,8 @@ RSpec.describe ApolloFederation::ServiceField do
             @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
 
           type Position {
-            x: Int! @federation__shareable
-            y: Int! @federation__shareable
+            x: Int! @shareable
+            y: Int! @shareable
           }
 
           type Query {

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-            type Product @key(fields: "upc") {
+            type Product @federation__key(fields: "upc") {
               upc: String!
             }
 
@@ -136,9 +136,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-            type Product @key(fields: "upc") {
+            type Product @federation__key(fields: "upc") {
               upc: String!
             }
           GRAPHQL
@@ -175,7 +175,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             upc: String!
@@ -210,7 +210,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product @federation__extends {
             upc: String!
@@ -246,9 +246,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Position @shareable {
+          type Position @federation__shareable {
             x: Int!
             y: Int!
           }
@@ -283,7 +283,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position @inaccessible {
             x: Int!
@@ -320,7 +320,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position @tag(name: "private") {
             x: Int!
@@ -357,7 +357,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
             type Product @fed2__extends {
               upc: String!
@@ -393,9 +393,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
-            type Position @shareable {
+            type Position @fed2__shareable {
               x: Int!
               y: Int!
             }
@@ -430,7 +430,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
             type Position @inaccessible {
               x: Int!
@@ -467,7 +467,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
             type Position @tag(name: "private") {
               x: Int!
@@ -503,9 +503,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
-            type Product @key(fields: "upc") {
+            type Product @fed2__key(fields: "upc") {
               upc: String!
             }
 
@@ -534,9 +534,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
-            type Product @fed2__extends @key(fields: "upc") {
+            type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
               upc: String! @fed2__external
             }
@@ -561,9 +561,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
-            type Product @fed2__interfaceObject @key(fields: "id") {
+            type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
             }
           GRAPHQL
@@ -615,7 +615,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Book implements Product {
             upc: String!
@@ -672,7 +672,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Book implements Product {
             upc: String!
@@ -735,17 +735,17 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Book implements Product @federation__extends @key(fields: "upc") {
+          type Book implements Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
           }
 
-          type Pen implements Product @key(fields: "upc") {
+          type Pen implements Product @federation__key(fields: "upc") {
             upc: String!
           }
 
-          interface Product @key(fields: "upc") {
+          interface Product @federation__key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -791,7 +791,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Book {
             upc: String!
@@ -840,7 +840,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Book {
             upc: String!
@@ -883,7 +883,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           enum ProductType @tag(name: "private") {
             BOOK
@@ -925,7 +925,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           enum ProductType @inaccessible {
             BOOK
@@ -966,7 +966,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             upc: UPC!
@@ -1012,7 +1012,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             upc: UPC!
@@ -1062,7 +1062,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1117,7 +1117,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1172,7 +1172,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1227,7 +1227,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1276,7 +1276,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1321,7 +1321,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1355,9 +1355,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @key(fields: "upc") @key(fields: "name") {
+          type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
             name: String
             upc: String!
           }
@@ -1381,9 +1381,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @key(fields: "upc", resolvable: false) {
+          type Product @federation__key(fields: "upc", resolvable: false) {
             upc: String!
           }
         GRAPHQL
@@ -1406,9 +1406,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @key(fields: "upc") {
+          type Product @federation__key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -1433,9 +1433,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__extends @key(fields: "upc") {
+          type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
             upc: String! @federation__external
           }
@@ -1460,9 +1460,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__interfaceObject @key(fields: "id") {
+          type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -1491,11 +1491,11 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position {
-            x: Int! @shareable
-            y: Int! @shareable
+            x: Int! @federation__shareable
+            y: Int! @federation__shareable
           }
 
           type Query {
@@ -1527,7 +1527,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position {
             x: Int! @inaccessible
@@ -1563,7 +1563,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position {
             x: Int! @tag(name: "private")
@@ -1599,7 +1599,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Position {
             x: Int! @tag(name: "private") @tag(name: "protected")
@@ -1651,7 +1651,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1707,7 +1707,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1763,7 +1763,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1799,9 +1799,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__extends @key(fields: "id") {
+          type Product @federation__extends @federation__key(fields: "id") {
             id: ID!
             isStock: Boolean! @federation__override(from: "Products")
           }
@@ -1835,14 +1835,14 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__extends @key(fields: "upc") {
+          type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
             upc: String! @federation__external
           }
 
-          type Review @key(fields: "id") {
+          type Review @federation__key(fields: "id") {
             id: ID!
             product: Product @federation__provides(fields: "upc")
           }
@@ -1870,9 +1870,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__extends @key(fields: "upc") {
+          type Product @federation__extends @federation__key(fields: "upc") {
             price: Int @federation__external
             shippingEstimate: Int @federation__requires(fields: "price weight")
             upc: String! @federation__external
@@ -1899,9 +1899,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-            type Product @key(fields: "productId") {
+            type Product @federation__key(fields: "productId") {
               productId: String!
             }
           GRAPHQL
@@ -1927,9 +1927,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-            type Product @federation__extends @key(fields: "product_id") {
+            type Product @federation__extends @federation__key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
               otherOptions: [String!]! @federation__requires(fields: "myId")
               product_id: String!
@@ -1960,9 +1960,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @federation__extends @key(fields: "upc") {
+          type Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
           }
         GRAPHQL
@@ -1988,9 +1988,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
 
-          type Product @key(fields: "id") {
+          type Product @federation__key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -2022,7 +2022,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
           type Product @fed2__extends {
             upc: String!
@@ -2059,7 +2059,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@key", "@shareable"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
 
           type Product @fed2__extends {
             upc: String!

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe ApolloFederation::ServiceField do
       schema = Class.new(base_schema) do
         query query_obj
         federation version: '2.0'
-        set_imported_directives %w[tag key]
+        import_directives %w[tag key]
       end
 
       expect(execute_sdl(schema)).to match_sdl(

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -334,6 +334,42 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns valid SDL for @key directives with custom imported_directives' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        key fields: :upc
+
+        field :upc, String, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true
+      end
+
+      schema = Class.new(base_schema) do
+        query query_obj
+        federation version: '2.0'
+        set_imported_directives %w[tag key]
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag", "@key"])
+
+          type Product @key(fields: "upc") {
+            upc: String!
+          }
+
+          type Query {
+            product: Product
+          }
+        GRAPHQL
+      )
+    end
+
     context 'with a custom link namespace provided' do
       it 'returns valid SDL for type extensions with custom namespace' do
         product = Class.new(base_object) do


### PR DESCRIPTION
Previously the directives imported by Apollo were static, only containing `@inaccesible` and `@tag`. 

This limited the user of the library to use e.g. the `@key` directive in the schema - but the same goes for any other directive - because they got prefixed with `federation__` to become `@federation__key`. 

Now this list of imported directives is configurable. 